### PR TITLE
Fix #123 - request paused on exit

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,10 +1,10 @@
 # graphql-upload changelog
 
-## 8.0.2
+## Next
 
 ### Patch
 
-- Fixed hanging when request with a large payload has an "immediate" error, such as a malformed request; [issue #123](https://github.com/jaydenseric/graphql-upload/issues/123) via [PR #124](https://github.com/jaydenseric/graphql-upload/pull/124).
+- Fixed hanging when a request with a large payload has an “immediate” error, such as a malformed request, fixing [#123](https://github.com/jaydenseric/graphql-upload/issues/123) via [#124](https://github.com/jaydenseric/graphql-upload/pull/124).
 
 ## 8.0.1
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # graphql-upload changelog
 
+## 8.0.2
+
+### Patch
+
+- Fixed hanging when request with a large payload has an "immediate" error, such as a malformed request; [issue #123](https://github.com/jaydenseric/graphql-upload/issues/123) via [PR #124](https://github.com/jaydenseric/graphql-upload/pull/124).
+
 ## 8.0.1
 
 ### Patch

--- a/src/processRequest.mjs
+++ b/src/processRequest.mjs
@@ -151,7 +151,7 @@ export const processRequest = (
 
       // With a sufficiently large request body, subsequent events in the same
       // event frame cause the stream to pause after the parser is destroyed. To
-      // ensure that the request resumes, we schedule the call to .resume() for
+      // ensure that the request resumes, the call to .resume() is scheduled for
       // later in the event loop.
       setImmediate(() => {
         request.resume()

--- a/src/processRequest.mjs
+++ b/src/processRequest.mjs
@@ -148,7 +148,9 @@ export const processRequest = (
           if (!upload.file) upload.reject(exitError)
 
       request.unpipe(parser)
-      request.resume()
+      setImmediate(() => {
+        request.resume()
+      })
     }
 
     /**

--- a/src/processRequest.mjs
+++ b/src/processRequest.mjs
@@ -148,6 +148,11 @@ export const processRequest = (
           if (!upload.file) upload.reject(exitError)
 
       request.unpipe(parser)
+
+      // With a sufficiently large request body, subsequent events in the same
+      // event frame cause the stream to pause after the parser is destroyed. To
+      // ensure that the request resumes, we schedule the call to .resume() for
+      // later in the event loop.
       setImmediate(() => {
         request.resume()
       })

--- a/src/test.mjs
+++ b/src/test.mjs
@@ -154,9 +154,10 @@ t.test('Invalid ‘operations’ JSON.', async t => {
     body.append('operations', '{ variables: { "file": null } }')
     body.append('map', JSON.stringify({ 1: ['variables.file'] }))
 
-    // We need at least one of these "immediate" failures to have a request body
-    // larger than node's internal stream buffer, so that we can test stream
-    // resumption. https://github.com/jaydenseric/graphql-upload/issues/123
+    // We need at least one of these “immediate” failures to have a request body
+    // larger than node’s internal stream buffer, so that we can test stream
+    // resumption.
+    // See: https://github.com/jaydenseric/graphql-upload/issues/123
     body.append('1', 'a'.repeat(70000), { filename: 'a.txt' })
 
     const { status } = await fetch(`http://localhost:${port}`, {

--- a/src/test.mjs
+++ b/src/test.mjs
@@ -153,6 +153,10 @@ t.test('Invalid ‘operations’ JSON.', async t => {
 
     body.append('operations', '{ variables: { "file": null } }')
     body.append('map', JSON.stringify({ 1: ['variables.file'] }))
+
+    // We need at least one of these "immediate" failures to have a request body
+    // larger than node's internal stream buffer, so that we can test stream
+    // resumption. https://github.com/jaydenseric/graphql-upload/issues/123
     body.append('1', 'a'.repeat(70000), { filename: 'a.txt' })
 
     const { status } = await fetch(`http://localhost:${port}`, {

--- a/src/test.mjs
+++ b/src/test.mjs
@@ -153,7 +153,7 @@ t.test('Invalid ‘operations’ JSON.', async t => {
 
     body.append('operations', '{ variables: { "file": null } }')
     body.append('map', JSON.stringify({ 1: ['variables.file'] }))
-    body.append('1', 'a', { filename: 'a.txt' })
+    body.append('1', 'a'.repeat(70000), { filename: 'a.txt' })
 
     const { status } = await fetch(`http://localhost:${port}`, {
       method: 'POST',


### PR DESCRIPTION
It appears that subsequent operations which have the effect of pausing the request are already queued for this event frame. This fix adds setImmediate to push stream resumption to the next frame.

In the future, we should run tests with a small payload AND one that exceeds the maximum TCP packet size limit and node internal buffer. This would help identify this kind of bug.