### PR TITLE
Fix and test for invalid `operations` and `map` field types

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,11 @@
 ### Patch
 
 - Updated dependencies.
+- Handle invalid types in multipart fields and respond with meaningful HTTP 400 errors, via [#139](https://github.com/jaydenseric/graphql-upload/pull/139):
+  - Invalid `operations` type.
+  - Invalid `map` type.
+  - Invalid `map` entry type.
+  - Invalid `map` entry array item type.
 - Removed the [`watch`](https://npm.im/watch) dev dependency and `watch` script.
 - Simplified the `prepublishOnly` script.
 

--- a/src/processRequest.mjs
+++ b/src/processRequest.mjs
@@ -242,6 +242,14 @@ export const processRequest = (
 
           map = new Map()
           for (const [fieldName, paths] of mapEntries) {
+            if (!Array.isArray(paths))
+              return exit(
+                createError(
+                  400,
+                  `Invalid type for the ‘map’ multipart field key ‘${fieldName}’ value (${SPEC_URL}).`
+                )
+              )
+
             map.set(fieldName, new Upload())
 
             for (const path of paths)

--- a/src/processRequest.mjs
+++ b/src/processRequest.mjs
@@ -155,6 +155,10 @@ export const processRequest = (
         case 'operations':
           try {
             operations = JSON.parse(value)
+            if (typeof operations !== 'object')
+              throw new Error(
+                `‘operations’ was of type ${typeof operations} while expecting object`
+              )
             operationsPath = objectPath(operations)
           } catch (error) {
             exit(
@@ -191,6 +195,14 @@ export const processRequest = (
           if (mapEntries.length > maxFiles)
             return exit(
               createError(413, `${maxFiles} max file uploads exceeded.`)
+            )
+
+          if (typeof operations !== 'object')
+            return exit(
+              createError(
+                400,
+                `Invalid JSON in the ‘operations’ multipart field (${SPEC_URL}).`
+              )
             )
 
           map = new Map()

--- a/src/processRequest.mjs
+++ b/src/processRequest.mjs
@@ -15,6 +15,31 @@ import objectPath from 'object-path'
 const SPEC_URL = 'https://github.com/jaydenseric/graphql-multipart-request-spec'
 
 /**
+ * Checks if a value is an object with properties.
+ * @kind function
+ * @name isObject
+ * @param {*} value Value to check.
+ * @returns {boolean} Is the value an object.
+ * @ignore
+ */
+const isObject = value => value && value.constructor === Object
+
+/**
+ * Safely ignores a readable stream.
+ * @kind function
+ * @name ignoreStream
+ * @param {ReadableStream} stream Readable stream.
+ * @ignore
+ */
+const ignoreStream = stream => {
+  // Prevent an unhandled error from crashing the process.
+  stream.on('error', () => {})
+
+  // Waste the stream.
+  stream.resume()
+}
+
+/**
  * An expected file upload.
  * @kind class
  * @name Upload
@@ -151,23 +176,31 @@ export const processRequest = (
     }
 
     parser.on('field', (fieldName, value) => {
+      if (exitError) return
+
       switch (fieldName) {
         case 'operations':
           try {
             operations = JSON.parse(value)
-            if (typeof operations !== 'object')
-              throw new Error(
-                `‘operations’ was of type ${typeof operations} while expecting object`
-              )
-            operationsPath = objectPath(operations)
           } catch (error) {
-            exit(
+            return exit(
               createError(
                 400,
                 `Invalid JSON in the ‘operations’ multipart field (${SPEC_URL}).`
               )
             )
           }
+
+          if (!isObject(operations))
+            return exit(
+              createError(
+                400,
+                `Invalid type for the ‘operations’ multipart field (${SPEC_URL}).`
+              )
+            )
+
+          operationsPath = objectPath(operations)
+
           break
         case 'map': {
           if (!operations)
@@ -178,9 +211,9 @@ export const processRequest = (
               )
             )
 
-          let mapEntries
+          let parsedMap
           try {
-            mapEntries = Object.entries(JSON.parse(value))
+            parsedMap = JSON.parse(value)
           } catch (error) {
             return exit(
               createError(
@@ -190,19 +223,13 @@ export const processRequest = (
             )
           }
 
+          const mapEntries = Object.entries(parsedMap)
+
           // Check max files is not exceeded, even though the number of files to
           // parse might not match the map provided by the client.
           if (mapEntries.length > maxFiles)
             return exit(
               createError(413, `${maxFiles} max file uploads exceeded.`)
-            )
-
-          if (typeof operations !== 'object')
-            return exit(
-              createError(
-                400,
-                `Invalid JSON in the ‘operations’ multipart field (${SPEC_URL}).`
-              )
             )
 
           map = new Map()
@@ -219,11 +246,13 @@ export const processRequest = (
     })
 
     parser.on('file', (fieldName, stream, filename, encoding, mimetype) => {
-      if (!map) {
-        // Prevent an unhandled error from crashing the process.
-        stream.on('error', () => {})
-        stream.resume()
+      if (exitError) {
+        ignoreStream(stream)
+        return
+      }
 
+      if (!map) {
+        ignoreStream(stream)
         return exit(
           createError(
             400,
@@ -238,58 +267,59 @@ export const processRequest = (
       })
 
       const upload = map.get(fieldName)
-      if (upload) {
-        const capacitor = new WriteStream()
 
-        capacitor.on('error', () => {
-          stream.unpipe()
-          stream.resume()
-        })
-
-        stream.on('limit', () => {
-          if (currentStream === stream) currentStream = null
-          stream.unpipe()
-          capacitor.destroy(
-            createError(413, 'File truncated as it exceeds the size limit.')
-          )
-        })
-
-        stream.on('error', error => {
-          if (currentStream === stream) currentStream = null
-
-          stream.unpipe()
-          capacitor.destroy(exitError || error)
-        })
-
-        stream.pipe(capacitor)
-
-        const file = {
-          filename,
-          mimetype,
-          encoding,
-          createReadStream() {
-            const error = capacitor.error || (released ? exitError : null)
-            if (error) throw error
-            return capacitor.createReadStream()
-          }
-        }
-
-        let capacitorStream
-        Object.defineProperty(file, 'stream', {
-          get: util.deprecate(function() {
-            if (!capacitorStream) capacitorStream = this.createReadStream()
-            return capacitorStream
-          }, 'File upload property ‘stream’ is deprecated. Use ‘createReadStream()’ instead.')
-        })
-
-        Object.defineProperty(file, 'capacitor', { value: capacitor })
-
-        upload.resolve(file)
-      } else {
-        // Discard the unexpected file.
-        stream.on('error', () => {})
-        stream.resume()
+      if (!upload) {
+        // The file is extraneous. As the rest can still be processed, just
+        // ignore it and don’t exit with an error.
+        ignoreStream(stream)
+        return
       }
+
+      const capacitor = new WriteStream()
+
+      capacitor.on('error', () => {
+        stream.unpipe()
+        stream.resume()
+      })
+
+      stream.on('limit', () => {
+        if (currentStream === stream) currentStream = null
+        stream.unpipe()
+        capacitor.destroy(
+          createError(413, 'File truncated as it exceeds the size limit.')
+        )
+      })
+
+      stream.on('error', error => {
+        if (currentStream === stream) currentStream = null
+        stream.unpipe()
+        capacitor.destroy(exitError || error)
+      })
+
+      stream.pipe(capacitor)
+
+      const file = {
+        filename,
+        mimetype,
+        encoding,
+        createReadStream() {
+          const error = capacitor.error || (released ? exitError : null)
+          if (error) throw error
+          return capacitor.createReadStream()
+        }
+      }
+
+      let capacitorStream
+      Object.defineProperty(file, 'stream', {
+        get: util.deprecate(function() {
+          if (!capacitorStream) capacitorStream = this.createReadStream()
+          return capacitorStream
+        }, 'File upload property ‘stream’ is deprecated. Use ‘createReadStream()’ instead.')
+      })
+
+      Object.defineProperty(file, 'capacitor', { value: capacitor })
+
+      upload.resolve(file)
     })
 
     parser.once('filesLimit', () =>

--- a/src/processRequest.mjs
+++ b/src/processRequest.mjs
@@ -223,6 +223,14 @@ export const processRequest = (
             )
           }
 
+          if (!isObject(parsedMap))
+            return exit(
+              createError(
+                400,
+                `Invalid type for the ‘map’ multipart field (${SPEC_URL}).`
+              )
+            )
+
           const mapEntries = Object.entries(parsedMap)
 
           // Check max files is not exceeded, even though the number of files to

--- a/src/processRequest.mjs
+++ b/src/processRequest.mjs
@@ -25,6 +25,16 @@ const SPEC_URL = 'https://github.com/jaydenseric/graphql-multipart-request-spec'
 const isObject = value => value && value.constructor === Object
 
 /**
+ * Checks if a value is a string.
+ * @kind function
+ * @name isString
+ * @param {*} value Value to check.
+ * @returns {boolean} Is the value a string.
+ * @ignore
+ */
+const isString = value => typeof value === 'string' || value instanceof String
+
+/**
  * Safely ignores a readable stream.
  * @kind function
  * @name ignoreStream
@@ -246,14 +256,23 @@ export const processRequest = (
               return exit(
                 createError(
                   400,
-                  `Invalid type for the ‘map’ multipart field key ‘${fieldName}’ value (${SPEC_URL}).`
+                  `Invalid type for the ‘map’ multipart field entry key ‘${fieldName}’ array (${SPEC_URL}).`
                 )
               )
 
             map.set(fieldName, new Upload())
 
-            for (const path of paths)
+            for (const [index, path] of paths.entries()) {
+              if (!isString(path))
+                return exit(
+                  createError(
+                    400,
+                    `Invalid type for the ‘map’ multipart field entry key ‘${fieldName}’ array index ‘${index}’ value (${SPEC_URL}).`
+                  )
+                )
+
               operationsPath.set(path, map.get(fieldName).promise)
+            }
           }
 
           resolve(operations)

--- a/src/test.mjs
+++ b/src/test.mjs
@@ -201,12 +201,12 @@ t.test('Invalid ‘operations’ JSON.', async t => {
   })
 })
 
-t.test('Invalid ‘operations’ JSON - string instead of object.', async t => {
+t.test('Invalid ‘operations’ type.', async t => {
   const sendRequest = async (t, port) => {
     const body = new FormData()
 
-    body.append('operations', '"{}"')
-    body.append('map', '"{}"')
+    body.append('operations', '""')
+    body.append('map', JSON.stringify({ 1: ['variables.file'] }))
 
     // We need at least one of these “immediate” failures to have a request body
     // larger than node’s internal stream buffer, so that we can test stream
@@ -266,6 +266,60 @@ t.test('Invalid ‘map’ JSON.', async t => {
       })
     )
     body.append('map', '{ 1: ["variables.file"] }')
+    body.append('1', 'a', { filename: 'a.txt' })
+
+    const { status } = await fetch(`http://localhost:${port}`, {
+      method: 'POST',
+      body
+    })
+
+    t.equal(status, 400, 'Response status.')
+  }
+
+  await t.test('Koa middleware.', async t => {
+    t.plan(2)
+
+    const app = new Koa()
+      .on('error', error =>
+        t.matchSnapshot(snapshotError(error), 'Middleware throws.')
+      )
+      .use(graphqlUploadKoa())
+
+    const port = await startServer(t, app)
+
+    await sendRequest(t, port)
+  })
+
+  await t.test('Express middleware.', async t => {
+    t.plan(2)
+
+    const app = express()
+      .use(graphqlUploadExpress({ maxFiles: 1 }))
+      .use((error, request, response, next) => {
+        if (response.headersSent) return next(error)
+        t.matchSnapshot(snapshotError(error), 'Middleware throws.')
+        response.send()
+      })
+
+    const port = await startServer(t, app)
+
+    await sendRequest(t, port)
+  })
+})
+
+t.todo('Invalid ‘map’ type.', async t => {
+  const sendRequest = async (t, port) => {
+    const body = new FormData()
+
+    body.append(
+      'operations',
+      JSON.stringify({
+        variables: {
+          file: null
+        }
+      })
+    )
+    body.append('map', '""')
     body.append('1', 'a', { filename: 'a.txt' })
 
     const { status } = await fetch(`http://localhost:${port}`, {

--- a/src/test.mjs
+++ b/src/test.mjs
@@ -205,7 +205,7 @@ t.test('Invalid ‘operations’ type.', async t => {
   const sendRequest = async (t, port) => {
     const body = new FormData()
 
-    body.append('operations', '""')
+    body.append('operations', 'null')
     body.append('map', JSON.stringify({ 1: ['variables.file'] }))
 
     // We need at least one of these “immediate” failures to have a request body
@@ -319,7 +319,7 @@ t.todo('Invalid ‘map’ type.', async t => {
         }
       })
     )
-    body.append('map', '""')
+    body.append('map', 'null')
     body.append('1', 'a', { filename: 'a.txt' })
 
     const { status } = await fetch(`http://localhost:${port}`, {

--- a/src/test.mjs
+++ b/src/test.mjs
@@ -307,7 +307,7 @@ t.test('Invalid ‘map’ JSON.', async t => {
   })
 })
 
-t.todo('Invalid ‘map’ type.', async t => {
+t.test('Invalid ‘map’ type.', async t => {
   const sendRequest = async (t, port) => {
     const body = new FormData()
 

--- a/src/test.mjs
+++ b/src/test.mjs
@@ -361,7 +361,7 @@ t.test('Invalid ‘map’ type.', async t => {
   })
 })
 
-t.test('Invalid ‘map’ property type.', async t => {
+t.test('Invalid ‘map’ entry type.', async t => {
   const sendRequest = async (t, port) => {
     const body = new FormData()
 
@@ -374,6 +374,60 @@ t.test('Invalid ‘map’ property type.', async t => {
       })
     )
     body.append('map', JSON.stringify({ 1: null }))
+    body.append('1', 'a', { filename: 'a.txt' })
+
+    const { status } = await fetch(`http://localhost:${port}`, {
+      method: 'POST',
+      body
+    })
+
+    t.equal(status, 400, 'Response status.')
+  }
+
+  await t.test('Koa middleware.', async t => {
+    t.plan(2)
+
+    const app = new Koa()
+      .on('error', error =>
+        t.matchSnapshot(snapshotError(error), 'Middleware throws.')
+      )
+      .use(graphqlUploadKoa())
+
+    const port = await startServer(t, app)
+
+    await sendRequest(t, port)
+  })
+
+  await t.test('Express middleware.', async t => {
+    t.plan(2)
+
+    const app = express()
+      .use(graphqlUploadExpress({ maxFiles: 1 }))
+      .use((error, request, response, next) => {
+        if (response.headersSent) return next(error)
+        t.matchSnapshot(snapshotError(error), 'Middleware throws.')
+        response.send()
+      })
+
+    const port = await startServer(t, app)
+
+    await sendRequest(t, port)
+  })
+})
+
+t.test('Invalid ‘map’ entry array item type.', async t => {
+  const sendRequest = async (t, port) => {
+    const body = new FormData()
+
+    body.append(
+      'operations',
+      JSON.stringify({
+        variables: {
+          file: null
+        }
+      })
+    )
+    body.append('map', JSON.stringify({ 1: [null] }))
     body.append('1', 'a', { filename: 'a.txt' })
 
     const { status } = await fetch(`http://localhost:${port}`, {

--- a/tap-snapshots/lib-test-TAP.test.js
+++ b/tap-snapshots/lib-test-TAP.test.js
@@ -41,20 +41,20 @@ exports[`lib/test TAP Invalid ‘operations’ JSON. Express middleware. > Middl
 }
 `
 
-exports[`lib/test TAP Invalid ‘operations’ JSON - string instead of object. Koa middleware. > Middleware throws. 1`] = `
+exports[`lib/test TAP Invalid ‘operations’ type. Koa middleware. > Middleware throws. 1`] = `
 {
   "name": "BadRequestError",
-  "message": "Invalid JSON in the ‘operations’ multipart field (https://github.com/jaydenseric/graphql-multipart-request-spec).",
+  "message": "Invalid type for the ‘operations’ multipart field (https://github.com/jaydenseric/graphql-multipart-request-spec).",
   "status": 400,
   "statusCode": 400,
   "expose": true
 }
 `
 
-exports[`lib/test TAP Invalid ‘operations’ JSON - string instead of object. Express middleware. > Middleware throws. 1`] = `
+exports[`lib/test TAP Invalid ‘operations’ type. Express middleware. > Middleware throws. 1`] = `
 {
   "name": "BadRequestError",
-  "message": "Invalid JSON in the ‘operations’ multipart field (https://github.com/jaydenseric/graphql-multipart-request-spec).",
+  "message": "Invalid type for the ‘operations’ multipart field (https://github.com/jaydenseric/graphql-multipart-request-spec).",
   "status": 400,
   "statusCode": 400,
   "expose": true

--- a/tap-snapshots/lib-test-TAP.test.js
+++ b/tap-snapshots/lib-test-TAP.test.js
@@ -101,20 +101,40 @@ exports[`lib/test TAP Invalid ‘map’ type. Express middleware. > Middleware t
 }
 `
 
-exports[`lib/test TAP Invalid ‘map’ property type. Koa middleware. > Middleware throws. 1`] = `
+exports[`lib/test TAP Invalid ‘map’ entry type. Koa middleware. > Middleware throws. 1`] = `
 {
   "name": "BadRequestError",
-  "message": "Invalid type for the ‘map’ multipart field key ‘1’ value (https://github.com/jaydenseric/graphql-multipart-request-spec).",
+  "message": "Invalid type for the ‘map’ multipart field entry key ‘1’ array (https://github.com/jaydenseric/graphql-multipart-request-spec).",
   "status": 400,
   "statusCode": 400,
   "expose": true
 }
 `
 
-exports[`lib/test TAP Invalid ‘map’ property type. Express middleware. > Middleware throws. 1`] = `
+exports[`lib/test TAP Invalid ‘map’ entry type. Express middleware. > Middleware throws. 1`] = `
 {
   "name": "BadRequestError",
-  "message": "Invalid type for the ‘map’ multipart field key ‘1’ value (https://github.com/jaydenseric/graphql-multipart-request-spec).",
+  "message": "Invalid type for the ‘map’ multipart field entry key ‘1’ array (https://github.com/jaydenseric/graphql-multipart-request-spec).",
+  "status": 400,
+  "statusCode": 400,
+  "expose": true
+}
+`
+
+exports[`lib/test TAP Invalid ‘map’ entry array item type. Koa middleware. > Middleware throws. 1`] = `
+{
+  "name": "BadRequestError",
+  "message": "Invalid type for the ‘map’ multipart field entry key ‘1’ array index ‘0’ value (https://github.com/jaydenseric/graphql-multipart-request-spec).",
+  "status": 400,
+  "statusCode": 400,
+  "expose": true
+}
+`
+
+exports[`lib/test TAP Invalid ‘map’ entry array item type. Express middleware. > Middleware throws. 1`] = `
+{
+  "name": "BadRequestError",
+  "message": "Invalid type for the ‘map’ multipart field entry key ‘1’ array index ‘0’ value (https://github.com/jaydenseric/graphql-multipart-request-spec).",
   "status": 400,
   "statusCode": 400,
   "expose": true

--- a/tap-snapshots/lib-test-TAP.test.js
+++ b/tap-snapshots/lib-test-TAP.test.js
@@ -81,6 +81,26 @@ exports[`lib/test TAP Invalid ‘map’ JSON. Express middleware. > Middleware t
 }
 `
 
+exports[`lib/test TAP Invalid ‘map’ type. Koa middleware. > Middleware throws. 1`] = `
+{
+  "name": "BadRequestError",
+  "message": "Invalid type for the ‘map’ multipart field (https://github.com/jaydenseric/graphql-multipart-request-spec).",
+  "status": 400,
+  "statusCode": 400,
+  "expose": true
+}
+`
+
+exports[`lib/test TAP Invalid ‘map’ type. Express middleware. > Middleware throws. 1`] = `
+{
+  "name": "BadRequestError",
+  "message": "Invalid type for the ‘map’ multipart field (https://github.com/jaydenseric/graphql-multipart-request-spec).",
+  "status": 400,
+  "statusCode": 400,
+  "expose": true
+}
+`
+
 exports[`lib/test TAP Handles unconsumed uploads. Koa middleware. Upload B. > Enumerable properties. 1`] = `
 {
   "filename": "b.txt",

--- a/tap-snapshots/lib-test-TAP.test.js
+++ b/tap-snapshots/lib-test-TAP.test.js
@@ -41,6 +41,26 @@ exports[`lib/test TAP Invalid ‘operations’ JSON. Express middleware. > Middl
 }
 `
 
+exports[`lib/test TAP Invalid ‘operations’ JSON - string instead of object. Koa middleware. > Middleware throws. 1`] = `
+{
+  "name": "BadRequestError",
+  "message": "Invalid JSON in the ‘operations’ multipart field (https://github.com/jaydenseric/graphql-multipart-request-spec).",
+  "status": 400,
+  "statusCode": 400,
+  "expose": true
+}
+`
+
+exports[`lib/test TAP Invalid ‘operations’ JSON - string instead of object. Express middleware. > Middleware throws. 1`] = `
+{
+  "name": "BadRequestError",
+  "message": "Invalid JSON in the ‘operations’ multipart field (https://github.com/jaydenseric/graphql-multipart-request-spec).",
+  "status": 400,
+  "statusCode": 400,
+  "expose": true
+}
+`
+
 exports[`lib/test TAP Invalid ‘map’ JSON. Koa middleware. > Middleware throws. 1`] = `
 {
   "name": "BadRequestError",

--- a/tap-snapshots/lib-test-TAP.test.js
+++ b/tap-snapshots/lib-test-TAP.test.js
@@ -101,6 +101,26 @@ exports[`lib/test TAP Invalid ‘map’ type. Express middleware. > Middleware t
 }
 `
 
+exports[`lib/test TAP Invalid ‘map’ property type. Koa middleware. > Middleware throws. 1`] = `
+{
+  "name": "BadRequestError",
+  "message": "Invalid type for the ‘map’ multipart field key ‘1’ value (https://github.com/jaydenseric/graphql-multipart-request-spec).",
+  "status": 400,
+  "statusCode": 400,
+  "expose": true
+}
+`
+
+exports[`lib/test TAP Invalid ‘map’ property type. Express middleware. > Middleware throws. 1`] = `
+{
+  "name": "BadRequestError",
+  "message": "Invalid type for the ‘map’ multipart field key ‘1’ value (https://github.com/jaydenseric/graphql-multipart-request-spec).",
+  "status": 400,
+  "statusCode": 400,
+  "expose": true
+}
+`
+
 exports[`lib/test TAP Handles unconsumed uploads. Koa middleware. Upload B. > Enumerable properties. 1`] = `
 {
   "filename": "b.txt",


### PR DESCRIPTION
When `operations` is of type `string`, and `operationsPath.set` is called, the error was not correctly propagated.