### PR TITLE
Remove redundant Node.js version compatibility logic

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 - Updated dev dependencies, some of which now require Node.js v10+.
 - Replaced the [`tap`](https://npm.im/tap) dev dependency with [`test-director`](https://npm.im/test-director), [`coverage-node`](https://npm.im/coverage-node), and [`hard-rejection`](https://npm.im/hard-rejection) to improve the dev experience and reduce the dev install size by ~75.7 MB. These new dev dependencies require Node.js v10+.
 - Reorganized files. This is only a breaking change for projects using undocumented deep imports.
+- Removed now redundant Node.js version compatibility logic in the `processRequest` function.
 
 ### Patch
 

--- a/lib/processRequest.js
+++ b/lib/processRequest.js
@@ -322,13 +322,7 @@ module.exports = function processRequest(
       stream.on('error', error => {
         fileError = error
         stream.unpipe()
-        capacitor.destroy(
-          // The error has to be managed two ways due to event differences
-          // across supported Node.js versions. 100% code coverage here is
-          // impossible.
-          // coverage ignore next line
-          exitError || error
-        )
+        capacitor.destroy(exitError)
       })
 
       const file = {


### PR DESCRIPTION
Removes now redundant Node.js version compatibility logic in the `processRequest` function. Now we have 100% code coverage without ignored lines 🎉

@mike-marcacci can you think of anything else that can be simplified?