### PR TITLE
Lambda support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@
 
 exports.GraphQLUpload = require('./GraphQLUpload')
 exports.processRequest = require('./processRequest')
+exports.processRequestLambda = require('./processRequestLambda')
 exports.graphqlUploadKoa = require('./graphqlUploadKoa')
 exports.graphqlUploadExpress = require('./graphqlUploadExpress')
 exports.Upload = require('./Upload')
@@ -66,4 +67,15 @@ exports.Upload = require('./Upload')
  * @prop {number} [maxFieldSize=1000000] Maximum allowed non-file multipart form field size in bytes; enough for your queries.
  * @prop {number} [maxFileSize=Infinity] Maximum allowed file size in bytes.
  * @prop {number} [maxFiles=Infinity] Maximum allowed number of files.
+ */
+
+/**
+ * Processes a [GraphQL multipart request](https://github.com/jaydenseric/graphql-multipart-request-spec).
+ * @kind typedef
+ * @name ProcessRequestLambdaFunction
+ * @type {Function}
+ * @param {IncomingMessage} event [AWS Lambda event instance](https://docs.aws.amazon.com/lambda/latest/dg/nodejs-handler.html).
+ * @param {ProcessRequestOptions} [options] Options for processing the request.
+ * @returns {Promise<GraphQLOperation | Array<GraphQLOperation>>} GraphQL operation or batch of operations for a GraphQL server to consume (usually as the request body).
+ * @see [`processRequestLambda`]{@link processRequestLambda}.
  */

--- a/lib/processRequestLambda.js
+++ b/lib/processRequestLambda.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { Readable, Writable } = require('stream')
+const createError = require('http-errors')
 const { processRequest } = require('./processRequest')
 
 /**
@@ -31,6 +32,28 @@ module.exports = function processRequestLambda(
 ) {
   const request = new Readable()
   const response = new Writable()
+  const contentType = event.headers['content-type']
+
+  if (!event.headers)
+    return new Promise((_, reject) => {
+      const error = createError('Invalid event, no headers found', 400)
+      reject(error)
+    })
+
+  if (!event.body)
+    return new Promise((_, reject) => {
+      const error = createError('Invalid event, no body found', 400)
+      reject(error)
+    })
+
+  if (!contentType.includes('multipart/form-data;'))
+    return new Promise((_, reject) => {
+      const error = createError(
+        `Invalid content-type ${contentType}, should be multipart/form-data;`,
+        400
+      )
+      reject(error)
+    })
 
   request.headers = event.headers
   request.push(event.body)

--- a/lib/processRequestLambda.js
+++ b/lib/processRequestLambda.js
@@ -2,7 +2,7 @@
 
 const { Readable, Writable } = require('stream')
 const createError = require('http-errors')
-const { processRequest } = require('./processRequest')
+const processRequest = require('./processRequest')
 
 /**
  * Used when handling file uploads on a lambda without the full Apollo-Server
@@ -54,7 +54,6 @@ module.exports = function processRequestLambda(
       )
       reject(error)
     })
-
   request.headers = event.headers
   request.push(event.body)
   request.push(null)

--- a/lib/processRequestLambda.js
+++ b/lib/processRequestLambda.js
@@ -1,0 +1,44 @@
+'use strict'
+
+const { Readable, Writable } = require('stream')
+const { processRequest } = require('./processRequest')
+
+/**
+ * Used when handling file uploads on a lambda without the full Apollo-Server
+ * Processes a [GraphQL multipart request](https://github.com/jaydenseric/graphql-multipart-request-spec).
+ * It parses the `operations` and `map` fields to create an
+ * [`Upload`]{@link Upload} instance for each expected file upload, placing
+ * references wherever the file is expected in the
+ * [GraphQL operation]{@link GraphQLOperation} for the
+ * [`Upload` scalar]{@link GraphQLUpload} to derive it’s value. Errors are
+ * created with [`http-errors`](https://npm.im/http-errors) to assist in
+ * sending responses with appropriate HTTP status codes.
+ * @kind function
+ * @name processRequestLambda
+ * @type {ProcessRequestLambdaFunction}
+ * @example <caption>How to import.</caption>
+ * ```js
+ * const { processRequestLambda } = require('graphql-upload')
+ * ```
+ */
+module.exports = function processRequestLambda(
+  event,
+  {
+    maxFieldSize = 1000000, // 1 MB
+    maxFileSize = Infinity,
+    maxFiles = Infinity
+  } = {}
+) {
+  const request = new Readable()
+  const response = new Writable()
+
+  request.headers = event.headers
+  request.push(event.body)
+  request.push(null)
+
+  return processRequest(request, response, {
+    maxFieldSize,
+    maxFileSize,
+    maxFiles
+  })
+}

--- a/test/index.js
+++ b/test/index.js
@@ -10,5 +10,6 @@ require('./lib/graphqlUploadKoa.test')(tests)
 require('./lib/ignoreStream.test')(tests)
 require('./lib/processRequest.test')(tests)
 require('./lib/Upload.test')(tests)
+require('./lib/processRequestLambda.test')(tests)
 
 tests.run()

--- a/test/lib/processRequestLambda.test.js
+++ b/test/lib/processRequestLambda.test.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const { ok, strictEqual } = require('assert')
+const FormData = require('form-data')
+const { ReadStream } = require('fs-capacitor')
+const Upload = require('../../lib/Upload')
+const processRequestLambda = require('../../lib/processRequestLambda')
+const streamToString = require('../streamToString')
+
+module.exports = tests => {
+  tests.add(
+    '`processRequestLambda` with a single file and default `createReadStream` options.',
+    async () => {
+      const body = new FormData()
+
+      body.append('operations', JSON.stringify({ variables: { file: null } }))
+      body.append('map', JSON.stringify({ '1': ['variables.file'] }))
+      body.append('1', 'a', { filename: 'a.txt' })
+
+      const headers = body.getHeaders()
+      const values = body.getBuffer().toString()
+
+      // Create a fake Lambda event
+      const event = {
+        body: values,
+        headers
+      }
+
+      const operation = await processRequestLambda(event)
+
+      ok(operation.variables.file instanceof Upload)
+
+      const upload = await operation.variables.file.promise
+
+      strictEqual(upload.filename, 'a.txt')
+      strictEqual(upload.mimetype, 'text/plain')
+      strictEqual(upload.encoding, '7bit')
+
+      const stream = upload.createReadStream()
+
+      ok(stream instanceof ReadStream)
+      strictEqual(stream._readableState.encoding, null)
+      strictEqual(stream.readableHighWaterMark, 16384)
+      strictEqual(await streamToString(stream), 'a')
+    }
+  )
+}


### PR DESCRIPTION
Goal is handle the use case of hosting the processRequest call in an AWS Lambda.

Happy to discuss.

Related to:
https://github.com/jaydenseric/graphql-upload/issues/155