### PR TITLE
update object-path to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "fs-capacitor": "^6.2.0",
     "http-errors": "^1.8.0",
     "isobject": "^4.0.0",
-    "object-path": "^0.11.6"
+    "object-path": "^0.11.7"
   },
   "devDependencies": {
     "coverage-node": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "fs-capacitor": "^6.2.0",
     "http-errors": "^1.8.0",
     "isobject": "^4.0.0",
-    "object-path": "^0.11.5"
+    "object-path": "^0.11.6"
   },
   "devDependencies": {
     "coverage-node": "^5.0.1",


### PR DESCRIPTION
there's a github advisory about a security fix and it affects downstream clients.

updating this means clients can just update to latest version of this and get the change https://github.com/advisories/GHSA-cwx2-736x-mf6w

```
CVE-2021-23434
moderate severity
Vulnerable versions: < 0.11.6
Patched version: 0.11.6
This affects the package object-path before 0.11.6. A type confusion vulnerability can lead to a bypass of CVE-2020-15256 when the path components used in the path parameter are arrays. In particular, the condition currentPath === 'proto' returns false if currentPath is ['proto']. This is because the === operator returns always false when the type of the operands is different.
```

`npm test` passes