### PR TITLE
fix: manually track if request is ended or not

### DIFF
--- a/public/processRequest.js
+++ b/public/processRequest.js
@@ -116,6 +116,11 @@ module.exports = function processRequest(
         for (const upload of map.values())
           if (upload.file) upload.file.capacitor.release();
     };
+    
+    
+    // `removeListener` might not have time to remove the listener from
+    // the `end` event, so let's track ut manually
+    let requestEnded = false;
 
     /**
      * Handles when the request is closed before it properly ended.
@@ -124,6 +129,9 @@ module.exports = function processRequest(
      * @ignore
      */
     const abort = () => {
+      if (requestEnded) {
+        return;
+      }
       exit(
         createError(
           499,
@@ -353,6 +361,7 @@ module.exports = function processRequest(
 
     request.once('close', abort);
     request.once('end', () => {
+      requestEnded = true;
       request.removeListener('close', abort);
     });
 


### PR DESCRIPTION
When upgrading from node 14 to node 16, we started getting `Request disconnected during file upload stream parsing.` errors. Putting some log statements inside the `end` and `close` event listeners shows that they are called in the correct order

![image](https://user-images.githubusercontent.com/1404810/139057000-8dca6a47-2480-4e10-9544-5a8daa1f57fb.png)

Using a boolean and manually tracking solves the issue.

I've tried to figure out if there were timing changes in the events in Node 16 without luck. I also don't know how to write a test for this...

---

For now I just use a patch to apply the change from this PR to our project. I don't really have the time to write a test, but I thought to open a PR in case it can be a start for a proper fix 🙂 