### PR TITLE
Updated readme file and comment in GraphQLUpload

### DIFF
--- a/GraphQLUpload.mjs
+++ b/GraphQLUpload.mjs
@@ -66,7 +66,7 @@ import Upload from "./Upload.mjs";
  * {@linkcode GraphQLUpload} scalar resolver value promise resolves:
  *
  * ```ts
- * import type { FileUpload } from "graphql-upload/processRequest.mjs";
+ * import { FileUpload } from 'graphql-upload/Upload.mjs';
  * ```
  */
 const GraphQLUpload = new GraphQLScalarType({

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,10 @@ A schema built with separate SDL and resolvers (e.g. using the function [`makeEx
 
 Then, the [`Upload`](./GraphQLUpload.mjs) scalar can be used for query or mutation arguments. For how to use the scalar value in resolvers, see the documentation in the module [`GraphQLUpload.mjs`](./GraphQLUpload.mjs).
 
+Note: If you're using TypeScript, you'll need to import the `FileUpload` interface from `'graphql-upload/Upload.mjs'` in order to use it in your code. You can do this with the following import statement:
+
+`import { FileUpload } from 'graphql-upload/Upload.mjs';`
+
 ## Examples
 
 - [Apollo upload examples repo](https://github.com/jaydenseric/apollo-upload-examples); a full stack demo of file uploads via GraphQL mutations using [`apollo-server-koa`](https://npm.im/apollo-server-koa) and [`@apollo/client`](https://npm.im/@apollo/client).


### PR DESCRIPTION
I have tried to use 'graphql-upload' today and I couldn't find the FileUpload interface for a while I only realized that I could take it from the graphql-upload/Upload.mjs file after I check the types of the package aka @types/graphql-upload so I figured I might make it easier for the next person and add it to the readmefile and fix that comment in GraphQLUpload.mjs file in line 69 from import type { FileUpload } from "graphql-upload/processRequest.mjs"; to * import { FileUpload } from 'graphql-upload/Upload.mjs'; which worked for me