### PR TITLE
fix: move parser's resolve() from `field` to `finish` event

### DIFF
--- a/processRequest.mjs
+++ b/processRequest.mjs
@@ -207,8 +207,6 @@ export default function processRequest(
               }
             }
           }
-
-          resolve(operations);
         }
       }
     });
@@ -311,6 +309,8 @@ export default function processRequest(
       for (const upload of map.values())
         if (!upload.file)
           upload.reject(createError(400, "File missing in the request."));
+
+      resolve(operations);
     });
 
     // Use the `on` method instead of `once` as in edge cases the same parser


### PR DESCRIPTION
Fix #384

We're encountering a situation where only the first `GraphQLUpload` argument in a GraphQL request gets processed. Subsequent arguments result in empty uploads. This behavior seems to be linked to the busboy parser's `field` event being triggered multiple times, corresponding to the number of GraphQLUpload arguments present.

To address this, we've moved the promise resolution to the `finish` event. This ensures that the promise only resolves after all files have been processed, successfully capturing all uploads in the request.
